### PR TITLE
Don't error on kernel headers in LOCAL_ADDITIONAL_DEPENDENCIES

### DIFF
--- a/core/base_rules.mk
+++ b/core/base_rules.mk
@@ -110,10 +110,14 @@ endif
 LOCAL_ADDITIONAL_DEPENDENCIES := $(filter-out %.mk,$(LOCAL_ADDITIONAL_DEPENDENCIES))
 
 my_bad_deps := $(strip $(foreach dep,$(filter-out | ||,$(LOCAL_ADDITIONAL_DEPENDENCIES)),\
-                 $(if $(findstring /,$(dep)),,$(dep))))
+                 $(if $(findstring /,$(dep)),,$(dep))))		
+my_bad_deps_sans_kernel := $(strip $(foreach dep,$(filter-out | ||,$(my_bad_deps)),\
+                 $(if $(findstring KERNEL_OBJ,$(dep)),,$(dep))))
+ifeq ($(my_bad_deps_sans_kernel),)
 ifneq ($(my_bad_deps),)
 $(call pretty-warning,"Bad LOCAL_ADDITIONAL_DEPENDENCIES: $(my_bad_deps)")
 $(call pretty-error,"LOCAL_ADDITIONAL_DEPENDENCIES must only contain paths (not module names)")
+endif
 endif
 
 ###########################################################


### PR DESCRIPTION
The new kernel header dependency path is wrongly picked up by this
logic. Check if KERNEL_OBJ is contained in the string and only error
if it isn't.